### PR TITLE
Save Station Assignments for reloading Field Control Page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 config.json
 wpa_keys.json
+station_assignments.json

--- a/freezy-ultralite.py
+++ b/freezy-ultralite.py
@@ -183,9 +183,21 @@ def clear_wpa_keys():
 
 @app.route('/update_display', methods=['POST'])
 def update_display():
-    data = request.get_json()
+    global station_assignments
+    data = request.get_json() or {}
+
     for station in STATION_KEYS:
         audience_display_teams[station] = data.get(station, "").strip()
+    
+
+    # 1. keep a copy of the team numbers
+    new_assign = {}
+    for key in STATION_KEYS:
+        new_assign[key] = data.get(key, "").strip()
+    station_assignments = new_assign
+    save_station_assignments(station_assignments)
+
+
     log("Audience display updated.")
     return jsonify({"status": "success"})
 
@@ -200,7 +212,16 @@ def push_config():
     if running:
         return jsonify({"status": "error", "message": "Cannot push config while timer is running!"})
 
-    data = request.get_json()
+    global station_assignments
+    data = request.get_json() or {}
+
+    # 1. keep a copy of the team numbers
+    new_assign = {}
+    for key in STATION_KEYS:
+        new_assign[key] = data.get(key, "").strip()
+    station_assignments = new_assign
+    save_station_assignments(station_assignments)
+
     stations = {}
     switch_entries = {}
 
@@ -235,6 +256,31 @@ def push_config():
     except Exception as e:
         log(f"Push config error: {e}")
         return jsonify({"status": "error", "message": str(e)})
+
+# -------------------------------------------------
+#  NEW: persist last-used station assignments
+# -------------------------------------------------
+STATION_ASSIGNMENTS_FILE = "station_assignments.json"
+
+@app.route('/get_station_assignments')
+def get_station_assignments():
+    return jsonify(station_assignments)
+
+def load_station_assignments():
+    if os.path.exists(STATION_ASSIGNMENTS_FILE):
+        try:
+            with open(STATION_ASSIGNMENTS_FILE, "r") as f:
+                return json.load(f)
+        except Exception:
+            pass
+    return {k: "" for k in STATION_KEYS}
+
+def save_station_assignments(data: dict):
+    with open(STATION_ASSIGNMENTS_FILE, "w") as f:
+        json.dump(data, f, indent=2)
+
+# load at startup
+station_assignments = load_station_assignments()
 
 def update_display_internal(stations):
     for station in STATION_KEYS:

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -47,6 +47,9 @@ background-color: #28a745 !important;
 .bg-danger {
 background-color: #dc3545 !important;
 }
+.bg-configured {
+background-color: #fffb00 !important;
+}
 .log-box {
 background: #ffffff;
 padding: 1rem;
@@ -154,12 +157,12 @@ padding: 0.35rem 0.5rem;
 }
 
 .blue-container {
-  background-color: #0033cc;
+  background-color: #001d75;
   color: white;
 }
 
 .red-container {
-  background-color: #cc0000;
+  background-color: #8a0202;
   color: white;
 }
 

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -7,6 +7,20 @@ $(function () {
     // set up timer: prefer SSE
     initUnifiedStream();
 
+    // -------------------------------------------------
+    //  Load saved station assignments (persisted on server)
+    // -------------------------------------------------
+    $.get('/get_station_assignments')
+    .done(function (data) {
+        Object.keys(data).forEach(function (key) {
+            const $input = $('#' + key);
+            if ($input.length) $input.val(data[key]);
+        });
+        // force badge update now that inputs are filled
+        refreshApStatusBadges();
+    })
+    .fail(function () { console.warn('Could not load saved assignments'); });
+
     // On page load, restore last timer value from localStorage
     const lastTimerSeconds = localStorage.getItem('lastTimerSeconds');
     if (lastTimerSeconds) {
@@ -306,6 +320,7 @@ function initUnifiedStream(retryDelayMs = 1500) {
     es.addEventListener('apstatus', (event) => {
         try {
             const data = JSON.parse(event.data);
+            window.currentApData = data;
             sseUpdateStationBadges(data);
         } catch (e) {
             console.error('Bad apstatus SSE data', e);
@@ -364,12 +379,25 @@ function sseUpdateStationBadges(apData) {
         badge.textContent = ssid;
 
         if (info.ssid) {
+            const stationKey = station;                 // e.g. "red1", "blue2"
+            const inputEl    = document.getElementById(stationKey);
+            const teamNum    = inputEl ? (inputEl.value || '').trim() : '';
+
+            // 2. Trim the SSID reported by the AP
+            const ssidTrimmed = (info.ssid || '').trim();
+
             if (linked) {
+                // Fully connected
                 badge.classList.add('bg-success', 'text-white');
                 badge.title =
                     `Connected – ${info.signalDbm || 0} dBm` +
                     (info.connectionQuality ? ` – ${info.connectionQuality}` : '');
+            } else if (ssidTrimmed === teamNum && teamNum !== '') {
+                // SSID matches the team number entered in the form, but not linked yet
+                badge.classList.add('bg-configured', 'text-black');
+                badge.title = 'Configured – waiting for client to connect';
             } else {
+                // SSID present but does NOT match the assigned team
                 badge.classList.add('bg-danger', 'text-white');
                 badge.title = 'Not connected';
             }
@@ -381,6 +409,14 @@ function sseUpdateStationBadges(apData) {
     });
 }
 
+function refreshApStatusBadges() {
+    // The server sends the current AP status every second via SSE.
+    // If the SSE connection is not yet open we just skip – it will
+    // be called automatically when the first `apstatus` event arrives.
+    if (window.currentApData) {
+        sseUpdateStationBadges(window.currentApData);
+    }
+}
 
 (function () {
   const params = new URLSearchParams(window.location.search);


### PR DESCRIPTION
New PR to save station assignments for preloading the field Control page with the last known configuration. 

Also Adds new colors to the AP status 

- Red ap data not match station assignment ( ap is configuring)
- Yellow ap data matches assignment. No team radio connected. 
- Green Team radio connected

Now saves when AP is not enabled